### PR TITLE
updated helm/rxintake/environments/pre-prod/version.yaml to use image shameson0708/redis:1.0.2

### DIFF
--- a/helm/rxintake/environments/pre-prod/version.yaml
+++ b/helm/rxintake/environments/pre-prod/version.yaml
@@ -2,4 +2,4 @@ deployment:
   image:
     repository: shameson0708
     name: redis
-    tag: 'x.x.x'
+    tag: '1.0.2'


### PR DESCRIPTION
updated helm/rxintake/environments/pre-prod/version.yaml to use image shameson0708/redis:1.0.2