### PR TITLE
updated helm/rxintake/environments/env10/Chart.yaml to use subchart rxintake:1.0.1

### DIFF
--- a/helm/rxintake/environments/env10/Chart.yaml
+++ b/helm/rxintake/environments/env10/Chart.yaml
@@ -6,4 +6,4 @@ version: 1.0.0
 dependencies:
   - name: rxintake
     repository: oci://kargoacr.azurecr.io/helm
-    version: 1.0.0
+    version: 1.0.1


### PR DESCRIPTION
updated helm/rxintake/environments/env10/Chart.yaml to use subchart rxintake:1.0.1